### PR TITLE
Revert "Fix decoede language for Windows cosole"

### DIFF
--- a/cmake.py
+++ b/cmake.py
@@ -30,7 +30,6 @@ import sys
 import glob
 import shutil
 import subprocess
-import locale
 import excons
 import excons.devtoolset
 import SCons.Script # pylint: disable=import-error
@@ -213,7 +212,7 @@ def Build(name, config=None, target=None):
 
     buf = ""
     while p.poll() is None:
-        r = p.stdout.readline(512).decode(locale.getdefaultlocale()[1]) if sys.version_info.major > 2 else p.stdout.readline(512)
+        r = p.stdout.readline(512).decode() if sys.version_info.major > 2 else p.stdout.readline(512)
         buf += r
         lines = buf.split("\n")
         if len(lines) > 1:


### PR DESCRIPTION
Reverts marza-animation-planet/excons#3

Ι have discovered bug in case set system locale to cp-437(english) on windows

in case sys locale is cp-437 and user locale is cp-932, ocrred bug
It may be better to set the compile machine as UTF-8(cp-65001) or english(cp-437) rather than in code.
